### PR TITLE
Remove Twitter handle and tracking code.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,7 @@ yandex_site_verification :
 
 # Social Sharing
 twitter:
-  username               : OpenSciPinay
+  username               :
 facebook:
   username               :
   app_id                 :
@@ -72,7 +72,7 @@ social:
 analytics:
   provider               : "google-universal"  # , "custom"
   google:
-    tracking_id          : UA-47668013-3
+    tracking_id          :
 
 
 # Site Author


### PR DESCRIPTION
Hi - it looks like you are still using my Twitter name and Google Analytics code.  So your website is going to my Twitter, and your web activity is showing up in my Google Analytics dashboard.  This pull request removes those.  Please merge.